### PR TITLE
Travis test always use latest version of Electron.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
   "author": "azu",
   "license": "MIT",
   "dependencies": {
-    "electron-zip-packager": "file:.."
+    "electron-zip-packager": "file:..",
+    "electron-prebuilt": ^1.3.1"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "example of electron zip",
   "main": "index.js",
   "scripts": {
-    "dist": "electron-zip-packager ./ video-transcript-note --platform=all --arch=all --version=1.2.5"
+    "dist": "electron-zip-packager ./ video-transcript-note --platform=all --arch=all"
   },
   "author": "azu",
   "license": "MIT",

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "electron-zip-packager": "file:..",
-    "electron-prebuilt": ^1.3.1"
+    "electron-prebuilt": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "travis-test": "(cd example && npm install && npm run dist)"
   },
   "dependencies": {
-    "archiver": "^1.0.0",
-    "electron-packager": "^7.1.0",
+    "archiver": "^1.0.1",
+    "electron-packager": "^7.5.1",
     "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
Also, minor things eg deps, adding electron-prebuilt to the example package.json
